### PR TITLE
Fix for updating cache - old items showing up as new

### DIFF
--- a/feeds.py
+++ b/feeds.py
@@ -132,7 +132,7 @@ class Feed(object):
             item.author = util.format(util.get(entry, 'author', '')) # TODO: max length
             if all(filter.filter(item) for filter in filters):
                 result.append(item)
-        self.id_set = new_id_set or self.id_set
+        self.id_set = new_id_set | self.id_set
         return result
         
 class Filter(object):


### PR DESCRIPTION
In the Poll method the comparison between new_id_set and self.id_set should use '|' instead of 'or'. In my tests this was causing the cache to be updated incorrectly ultimately resulting in items not being cached and showing up again as a new item on subsequent polls.
